### PR TITLE
VPC: added variables and parameters for Cloudwatch flow-log

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,23 @@ module "vpc" {
   enable_nat_gateway = true
   single_nat_gateway = var.single_nat
 
+
+
+  enable_flow_log                                 = var.enable_flow_log
+  create_flow_log_cloudwatch_log_group            = var.enable_flow_log && var.flow_log_destination_arn == ""
+  create_flow_log_cloudwatch_iam_role             = var.enable_flow_log && var.flow_log_cloudwatch_iam_role_arn == ""
+  flow_log_cloudwatch_log_group_retention_in_days = var.flow_log_cloudwatch_log_group_retention_in_days
+  flow_log_traffic_type                           = var.flow_log_traffic_type
+  flow_log_destination_arn                        = (var.enable_flow_log && var.flow_log_destination_arn != "") ? var.flow_log_destination_arn : ""
+  flow_log_cloudwatch_iam_role_arn                = (var.enable_flow_log && var.flow_log_cloudwatch_iam_role_arn != "") ? var.flow_log_cloudwatch_iam_role_arn : ""
+  flow_log_cloudwatch_log_group_name_prefix       = var.flow_log_cloudwatch_log_group_name_prefix
+  vpc_flow_log_tags = {
+    Name        = "${var.environment}-${var.cluster_name}"
+    Environment = var.environment
+    Project     = var.project
+    Terraform   = "true"
+  }
+
   enable_dns_hostnames = true
   enable_dns_support   = true
 

--- a/variables.tf
+++ b/variables.tf
@@ -45,3 +45,49 @@ variable "availability_zones" {
   type        = list(any)
   default     = []
 }
+
+
+
+variable "enable_flow_log" {
+  description = "Enable flow logs"
+  type        = bool
+  default     = false
+}
+
+
+
+variable "flow_log_cloudwatch_log_group_retention_in_days" {
+  description = "Retention days cloudwatch logs"
+  type        = number
+  default     = 90
+}
+
+
+
+variable "flow_log_traffic_type" {
+  description = "Traffic type (ACCEPT, REJECT, ALL)"
+  type        = string
+  default     = "ALL"
+}
+
+
+
+variable "flow_log_destination_arn" {
+  description = "cloudwatch destination arn"
+  type        = string
+  default     = ""
+}
+
+
+variable "flow_log_cloudwatch_iam_role_arn" {
+  description = "Iam role to use to push to cloudwatch"
+  type        = string
+  default     = ""
+}
+
+
+variable "flow_log_cloudwatch_log_group_name_prefix" {
+  description = "cloudwatch log group prefix"
+  type        = string
+  default     = "/aws/vpc-flow-log/"
+}


### PR DESCRIPTION
- added variables , where important one is `enable_flow_log`
- added parameters for sending flow logs to cloudwatch

issue #139